### PR TITLE
Remove the fake initctl file that confuses chef

### DIFF
--- a/debian-7/Dockerfile
+++ b/debian-7/Dockerfile
@@ -5,5 +5,6 @@ RUN /usr/bin/apt-get update
 RUN /usr/bin/apt-get -y install apt-transport-https curl emacs23-nox iptables iputils-ping kmod lsb-release lsof net-tools netcat nmap procps strace tcpdump telnet wget
 RUN wget http://launchpadlibrarian.net/173841617/init-system-helpers_1.18_all.deb
 RUN dpkg -i /init-system-helpers_1.18_all.deb
+RUN rm -rf /sbin/initctl
 
 CMD [ '/sbin/init' ]


### PR DESCRIPTION
This makes it look like Upstart when it's really sys-v