### PR TITLE
adding pinned versions of fedora

### DIFF
--- a/fedora-24/Dockerfile
+++ b/fedora-24/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:24
+LABEL maintainer="sean@sean.io"
+
+RUN dnf --best --allowerasing -y install curl emacs-nox gnupg2 initscripts iptables iputils lsof nc net-tools nmap procps strace systemd-sysv tcpdump telnet vim-minimal wget which
+
+CMD [ '/usr/lib/systemd/systemd' ]

--- a/fedora-25/Dockerfile
+++ b/fedora-25/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:25
+LABEL maintainer="sean@sean.io"
+
+RUN dnf -y install curl emacs-nox gnupg2 initscripts iptables iputils lsof nc net-tools nmap procps strace systemd-sysv tcpdump telnet vim wget which
+
+CMD [ '/usr/lib/systemd/systemd' ]

--- a/fedora-26/Dockerfile
+++ b/fedora-26/Dockerfile
@@ -1,0 +1,6 @@
+FROM fedora:26
+LABEL maintainer="sean@sean.io"
+
+RUN dnf -y install curl emacs-nox gnupg2 initscripts iptables iputils lsof nc net-tools nmap procps strace systemd-sysv tcpdump telnet vim wget which
+
+CMD [ '/usr/lib/systemd/systemd' ]


### PR DESCRIPTION
fedora-latest is currently fedora 26. docker currently only supports up to fedora 25 which is failing travis tests.