### PR TITLE
Use the vault repo for centos 5

### DIFF
--- a/centos-5/Dockerfile
+++ b/centos-5/Dockerfile
@@ -1,6 +1,9 @@
 FROM centos:5
 LABEL maintainer="sean@sean.io"
 
+RUN sed -i '/mirrorlist/d' /etc/yum.repos.d/*.repo
+RUN sed -i -e 's/#baseurl/baseurl/g' /etc/yum.repos.d/*.repo
+RUN sed -i -e 's/mirror.centos.org\/centos\/\$releasever/vault.centos.org\/5.11/g' /etc/yum.repos.d/*.repo
 RUN yum -y install curl emacs-nox gnupg2 initscripts iptables iputils lsof nc net-tools nmap openssl procps strace tcpdump telnet vim wget which
 
 CMD [ '/sbin/init' ]


### PR DESCRIPTION
The mirror list is gone now that centos 5 is EOL

Signed-off-by: Tim Smith <tsmith@chef.io>