### PR TITLE
ohai requires iproute2 package to get network info

### DIFF
--- a/ubuntu-17.04/Dockerfile
+++ b/ubuntu-17.04/Dockerfile
@@ -2,6 +2,6 @@ FROM ubuntu:17.04
 LABEL maintainer="sean@sean.io"
 
 RUN /usr/bin/apt-get update
-RUN /usr/bin/apt-get -y install apt-transport-https curl dirmngr emacs24-nox gnupg iptables iputils-ping kmod lsb-release lsof net-tools netcat nmap perl procps strace systemd tcpdump telnet vim wget
+RUN /usr/bin/apt-get -y install apt-transport-https curl dirmngr emacs24-nox gnupg iptables iputils-ping kmod lsb-release lsof net-tools netcat nmap perl procps strace systemd tcpdump telnet vim wget iproute2
 
 CMD [ '/bin/systemd' ]


### PR DESCRIPTION
docker cookbook makes use of node['ipaddress'] for tests, which is unavailable to ohai without this package. only an issue in zesty.