### PR TITLE
Fix not being able to start network services 

### DIFF
--- a/amazonlinux/Dockerfile
+++ b/amazonlinux/Dockerfile
@@ -1,6 +1,7 @@
 FROM amazonlinux:latest
 LABEL maintainer="sean@sean.io"
 
-RUN yum -y install passwd upstart util-linux curl emacs-nox gnupg2 initscripts iptables iputils lsof nc net-tools nmap openssl procps strace tcpdump telnet vim wget which
+RUN yum -y install passwd upstart util-linux curl emacs-nox gnupg2 initscripts iptables iputils lsof nc net-tools nmap openssl procps strace tcpdump telnet vim wget which kmod &&\
+    cat > /etc/sysconfig/network << "EOF"
 
 CMD [ "/sbin/init" ]


### PR DESCRIPTION
e.g. php-fpm on Amazon Linux

Resolves #18 

Related articles: https://www.linuxquestions.org/questions/red-hat-31/etc-sysconfig-network-no-such-file-or-directory-with-atheros-ar8161-nic-4175491039/