### PR TITLE
Fixes for Fedora >= 30

### DIFF
--- a/fedora-30/Dockerfile
+++ b/fedora-30/Dockerfile
@@ -1,0 +1,33 @@
+FROM fedora:30
+LABEL maintainer="sean@sean.io"
+
+RUN dnf -y install \
+    ca-certificates \
+    curl \
+    gnupg2 \
+    hostname \
+    initscripts \
+    iproute \
+    iptables \
+    iputils \
+    lsof \
+    nc \
+    net-tools \
+    nmap \
+    openssl \
+    passwd \
+    procps \
+    strace \
+    sudo \
+    systemd-sysv \
+    tcpdump \
+    telnet \
+    util-linux \
+    vim-minimal \
+    wget \
+    libxcrypt-compat \
+    which && \
+    dnf clean all && \
+    rm -rf /var/log/*
+
+CMD [ "/usr/lib/systemd/systemd" ]

--- a/fedora-latest/Dockerfile
+++ b/fedora-latest/Dockerfile
@@ -26,6 +26,7 @@ RUN dnf -y install \
     util-linux \
     vim-minimal \
     wget \
+    libxcrypt-compat \
     which && \
     dnf clean all && \
     rm -rf /var/log/*


### PR DESCRIPTION
- Add libxcrypt-compat to image as Fedora versions >= 30 require it to be installed or chef will complain about (and fail with) the missing libcrypt.so.1 library.

- Also add a specific Fedora 30 box.